### PR TITLE
Fix a bug in exaction dates

### DIFF
--- a/src/Khatovar/Bundle/ExactionBundle/Entity/ExactionRepository.php
+++ b/src/Khatovar/Bundle/ExactionBundle/Entity/ExactionRepository.php
@@ -42,10 +42,12 @@ class ExactionRepository extends EntityRepository
     public function getExactionsByYear($year)
     {
         $query = $this->createQueryBuilder('pe')
-            ->orderBy('pe.start', 'DESC')
             ->where('pe.start >= :start AND pe.start <= :end')
             ->setParameter('start', new \DateTime($year . '-01-01'))
             ->setParameter('end', new \DateTime($year . '-12-31'))
+            ->andWhere('pe.start <= :now')
+            ->setParameter('now', new \DateTime())
+            ->orderBy('pe.start', 'DESC')
             ->getQuery();
 
         return $query->getResult();
@@ -59,8 +61,9 @@ class ExactionRepository extends EntityRepository
     public function getFutureExactions()
     {
         $query = $this->createQueryBuilder('pf')
-            ->where('pf.start > :start')
-            ->setParameter('start', new \DateTime())
+            ->where('pf.start > :now')
+            ->setParameter('now', new \DateTime())
+            ->orderBy('pf.start', 'ASC')
             ->getQuery();
 
         return $query->getResult();


### PR DESCRIPTION
Exaction to comes contained all those of current year, and the past exactions of the current year also contained those still to come