### PR TITLE
Closes #31 - Remove "todo" from README

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,11 +1,3 @@
-| Q                    | A
-| -------------------- | -----
-| Bug report?          | yes/no
-| Feature request?     | yes/no
-| BC Break report?     | yes/no
-| RFC?                 | yes/no
-| khatovar-web version | x.y.z
-
 <!--
 - Please replace this comment by the description of your issue.
 -->

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,5 +29,4 @@ install:
 script:
     - vendor/bin/phpcs -p --standard=PSR2 --extensions=php features src
     - vendor/bin/php-cs-fixer fix --dry-run -v --diff --config=.php_cs.php
-    - vendor/bin/phpspec run
     - vendor/bin/behat features

--- a/README.md
+++ b/README.md
@@ -6,25 +6,6 @@
 
 This repository contain the source code of the CMS handling the web site of the medieval association : [“La compagnie franche du Khatovar”](http://www.compagniefranchedukhatovar.fr/)
 
-## TODO
-
-### Features
-- Synchronize ending date with starting date when creating a new exaction
-- Make time switch between exaction photos random
-- Optimize presentation on the photo admin page (accordion)
-- Optimize mobile theme (especially the menu)
-- Use photos instead of links in listing/index pages
-- Customize login page using the Khatovar theme
-- Make it possible to edit/organize the menu
-- RSS feeds
-- Connection to the facebook page and the blog for automatic posts when adding a new appearance
-
-### Technical
-- Use SASS
-- Use Foundation for the forms, buttons and accordion
-- Form fields that depends from one another must be dynamic (for example: hidding a field as long as an other one has not the correct value for it to be display)
-- Add behat tests
-
 ## Requirements
 
 - PHP 7.1+

--- a/composer.json
+++ b/composer.json
@@ -48,7 +48,6 @@
         "behat-extension/doctrine-data-fixtures-extension": "^4.0",
         "friendsofphp/php-cs-fixer": "^2.0",
         "phpmd/phpmd": "^2.4",
-        "phpspec/phpspec": "^4.0",
         "phpunit/phpunit": "^6.0",
         "sensio/generator-bundle": "^3.0",
         "squizlabs/php_codesniffer": "^3.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "75717259bb970a74a7ee3e663328653b",
+    "content-hash": "28552b3dfb354dd3e7ea32273cd52091",
     "packages": [
         {
             "name": "behat/transliterator",
@@ -110,7 +110,7 @@
             "keywords": [
                 "User management"
             ],
-            "time": "2017-08-05 09:06:53"
+            "time": "2017-08-05T09:06:53+00:00"
         },
         {
             "name": "composer/ca-bundle",
@@ -3978,125 +3978,6 @@
                 "pmd"
             ],
             "time": "2017-01-20T14:41:10+00:00"
-        },
-        {
-            "name": "phpspec/php-diff",
-            "version": "v1.1.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/phpspec/php-diff.git",
-                "reference": "0464787bfa7cd13576c5a1e318709768798bec6a"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/phpspec/php-diff/zipball/0464787bfa7cd13576c5a1e318709768798bec6a",
-                "reference": "0464787bfa7cd13576c5a1e318709768798bec6a",
-                "shasum": ""
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.0.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-0": {
-                    "Diff": "lib/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Chris Boulton",
-                    "homepage": "http://github.com/chrisboulton"
-                }
-            ],
-            "description": "A comprehensive library for generating differences between two hashable objects (strings or arrays).",
-            "time": "2016-04-07T12:29:16+00:00"
-        },
-        {
-            "name": "phpspec/phpspec",
-            "version": "4.0.2",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/phpspec/phpspec.git",
-                "reference": "eae06d6b409fc1479e2f12d0a9ab1a88e2fda94c"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/phpspec/phpspec/zipball/eae06d6b409fc1479e2f12d0a9ab1a88e2fda94c",
-                "reference": "eae06d6b409fc1479e2f12d0a9ab1a88e2fda94c",
-                "shasum": ""
-            },
-            "require": {
-                "doctrine/instantiator": "^1.0.5",
-                "ext-tokenizer": "*",
-                "php": "^7.0,<7.2",
-                "phpspec/php-diff": "^1.0.0",
-                "phpspec/prophecy": "^1.5",
-                "sebastian/exporter": "^1.0 || ^2.0 || ^3.0",
-                "symfony/console": "^3.2",
-                "symfony/event-dispatcher": "^3.2",
-                "symfony/finder": "^3.2",
-                "symfony/process": "^3.2",
-                "symfony/yaml": "^3.2"
-            },
-            "require-dev": {
-                "behat/behat": "^3.3",
-                "phpunit/phpunit": "^5.7|^6.0",
-                "symfony/filesystem": "^3.2"
-            },
-            "suggest": {
-                "phpspec/nyan-formatters": "Adds Nyan formatters"
-            },
-            "bin": [
-                "bin/phpspec"
-            ],
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "4.0.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-0": {
-                    "PhpSpec": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Konstantin Kudryashov",
-                    "email": "ever.zet@gmail.com",
-                    "homepage": "http://everzet.com"
-                },
-                {
-                    "name": "Marcello Duarte",
-                    "homepage": "http://marcelloduarte.net/"
-                },
-                {
-                    "name": "Ciaran McNulty",
-                    "homepage": "https://ciaranmcnulty.com/"
-                }
-            ],
-            "description": "Specification-oriented BDD framework for PHP 5.6+",
-            "homepage": "http://phpspec.net/",
-            "keywords": [
-                "BDD",
-                "SpecBDD",
-                "TDD",
-                "spec",
-                "specification",
-                "testing",
-                "tests"
-            ],
-            "time": "2017-08-05T20:11:20+00:00"
         },
         {
             "name": "phpspec/prophecy",


### PR DESCRIPTION
## Description

A lot of todo tasks were present in the `README.md` file. They have all been moved as GitHub issues.

## Definition Of Done

| Q                 | A
| ------------------| ---
| Added Specs       | -
| Added Behats      | -
| Changelog updated | -
| Migration script  | -
| Documentation     | -
| Fixed tickets     | #31

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
