### PR TITLE
Issue 96: Clean assertions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,7 @@
 
 ## Technical improvements
 
-- **Issue 34**: Reintegrate DocumentsBundle in the application, keep only UserBundle (vO.3) as a dependency.
-                Merge all "Khatovar" bundles in `KhatovarWebBundle`.
+- **Issue 34**: Reintegrate DocumentsBundle in the application, merge all "Khatovar" bundles in `KhatovarWebBundle`.
 - **Issue 46**: Remove the need for a root folder in database with ID "0".
 - **Issue 78**: Bring back the UserBundle inside the application.
 - Migrate on Symfony 3

--- a/behat.yaml
+++ b/behat.yaml
@@ -50,11 +50,11 @@ end-to-end:
                 - Khatovar\Tests\EndToEnd\Context\User\CommonContext: ~
                 - Khatovar\Tests\EndToEnd\Context\User\Administrator\AdminContext: ~
                 - Khatovar\Tests\EndToEnd\Context\User\Administrator\DeleteContext:
-                      - '@Khatovar\Tests\EndToEnd\Service\Assert\AssertUsersAreAdministrableOnes'
+                      - '@Khatovar\Tests\EndToEnd\Assertion\AssertUsersAreAdministrableOnes'
                 - Khatovar\Tests\EndToEnd\Context\User\Administrator\EditContext:
-                      - '@Khatovar\Tests\EndToEnd\Service\Assert\AssertUsersAreAdministrableOnes'
+                      - '@Khatovar\Tests\EndToEnd\Assertion\AssertUsersAreAdministrableOnes'
                 - Khatovar\Tests\EndToEnd\Context\User\Administrator\ListContext:
-                      - '@Khatovar\Tests\EndToEnd\Service\Assert\AssertUsersAreAdministrableOnes'
+                      - '@Khatovar\Tests\EndToEnd\Assertion\AssertUsersAreAdministrableOnes'
                 - Khatovar\Tests\EndToEnd\Context\User\Administrator\RoleContext:
                       - '@Khatovar\Component\User\Domain\Repository\UserRepositoryInterface'
                 - Khatovar\Tests\EndToEnd\Context\User\Administrator\StatusContext:
@@ -62,11 +62,11 @@ end-to-end:
                 - Khatovar\Tests\EndToEnd\Context\User\Administrator\SuperAdminContext: ~
                 - Khatovar\Tests\EndToEnd\Context\User\Administrator\ViewContext: ~
                 - Khatovar\Tests\EndToEnd\Context\User\Anonymous\AuthenticationContext:
-                      - '@Khatovar\Tests\EndToEnd\Service\Assert\AssertAuthenticatedAsUser'
-                      - '@Khatovar\Tests\EndToEnd\Service\Assert\AssertUserIsAnonymous'
+                      - '@Khatovar\Tests\EndToEnd\Assertion\AssertAuthenticatedAsUser'
+                      - '@Khatovar\Tests\EndToEnd\Assertion\AssertUserIsAnonymous'
                 - Khatovar\Tests\EndToEnd\Context\User\Anonymous\RegisterNewUserContext:
-                      - '@Khatovar\Tests\EndToEnd\Service\Assert\AssertAuthenticatedAsUser'
-                      - '@Khatovar\Tests\EndToEnd\Service\Assert\AssertUserIsAnonymous'
+                      - '@Khatovar\Tests\EndToEnd\Assertion\AssertAuthenticatedAsUser'
+                      - '@Khatovar\Tests\EndToEnd\Assertion\AssertUserIsAnonymous'
                       - '@Khatovar\Component\User\Domain\Repository\UserRepositoryInterface'
                 - Khatovar\Tests\EndToEnd\Context\User\Anonymous\ResetPasswordContext: ~
                 - Khatovar\Tests\EndToEnd\Context\User\RegularUser\ProfileContext: ~

--- a/docker/php/Dockerfile
+++ b/docker/php/Dockerfile
@@ -19,7 +19,7 @@ RUN apk add --no-cache \
     && pecl install apcu xdebug && docker-php-ext-enable apcu xdebug \
     && apk del .build-deps
 
-# Configure PHPH
+# Configure PHP
 RUN mv "$PHP_INI_DIR/php.ini-development" "$PHP_INI_DIR/php.ini"
 COPY files/khatovar.ini $PHP_INI_DIR/conf.d/
 COPY files/xdebug.ini $PHP_INI_DIR/conf.d/
@@ -27,6 +27,10 @@ COPY files/xdebug.ini $PHP_INI_DIR/conf.d/
 # Install composer
 RUN curl -sSL https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 RUN chmod +x /usr/local/bin/composer
+
+# Make XDEBUG activable at container start
+COPY files/docker-php-entrypoint /usr/local/bin/
+RUN chmod +x /usr/local/bin/docker-php-entrypoint && chmod 666 /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini
 
 # Expose port for PHP internal server
 EXPOSE 8000

--- a/docker/php/files/docker-php-entrypoint
+++ b/docker/php/files/docker-php-entrypoint
@@ -1,0 +1,29 @@
+#!/bin/sh
+set -e
+
+XDEBUG_PATH="/usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini"
+
+function activateXdebug {
+    echo "zend_extension=/usr/local/lib/php/extensions/no-debug-non-zts-20180731/xdebug.so" > ${XDEBUG_PATH}
+}
+
+function deactivateXdebug {
+    echo "" > ${XDEBUG_PATH}
+}
+
+if [[ ! -z "${XDEBUG_ENABLED}" ]]; then
+    if [[ "1" == "${XDEBUG_ENABLED}" ]]; then
+        activateXdebug
+    elif [[ "0" == "${XDEBUG_ENABLED}" ]]; then
+        deactivateXdebug
+    fi
+else
+    deactivateXdebug
+fi
+
+# first arg is `-f` or `--some-option`
+if [[ "${1#-}" != "$1" ]]; then
+	set -- php "$@"
+fi
+
+exec "$@"

--- a/tests/end-to-end/Assertion/AssertAuthenticatedAsUser.php
+++ b/tests/end-to-end/Assertion/AssertAuthenticatedAsUser.php
@@ -11,7 +11,7 @@ declare(strict_types=1);
  * file that was distributed with this source code.
  */
 
-namespace Khatovar\Tests\EndToEnd\Service\Assert;
+namespace Khatovar\Tests\EndToEnd\Assertion;
 
 use Symfony\Component\HttpKernel\KernelInterface;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;

--- a/tests/end-to-end/Assertion/AssertUserIsAnonymous.php
+++ b/tests/end-to-end/Assertion/AssertUserIsAnonymous.php
@@ -11,7 +11,7 @@ declare(strict_types=1);
  * file that was distributed with this source code.
  */
 
-namespace Khatovar\Tests\EndToEnd\Service\Assert;
+namespace Khatovar\Tests\EndToEnd\Assertion;
 
 use Symfony\Component\HttpKernel\KernelInterface;
 use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;

--- a/tests/end-to-end/Assertion/AssertUsersAreAdministrableOnes.php
+++ b/tests/end-to-end/Assertion/AssertUsersAreAdministrableOnes.php
@@ -11,7 +11,7 @@ declare(strict_types=1);
  * file that was distributed with this source code.
  */
 
-namespace Khatovar\Tests\EndToEnd\Service\Assert;
+namespace Khatovar\Tests\EndToEnd\Assertion;
 
 use Khatovar\Component\User\Application\Query\GetAdministrableUsers;
 use Symfony\Component\HttpKernel\KernelInterface;

--- a/tests/end-to-end/Context/User/Administrator/DeleteContext.php
+++ b/tests/end-to-end/Context/User/Administrator/DeleteContext.php
@@ -13,8 +13,8 @@ declare(strict_types=1);
 
 namespace Khatovar\Tests\EndToEnd\Context\User\Administrator;
 
+use Khatovar\Tests\EndToEnd\Assertion\AssertUsersAreAdministrableOnes;
 use Khatovar\Tests\EndToEnd\Context\User\UserRawContext;
-use Khatovar\Tests\EndToEnd\Service\Assert\AssertUsersAreAdministrableOnes;
 
 /**
  * @author Damien Carcel <damien.carcel@gmail.com>
@@ -38,9 +38,9 @@ final class DeleteContext extends UserRawContext
     }
 
     /**
-     * @Then I should be notified that user :username was removed
+     * @Then I should be notified that it was removed
      */
-    public function userWasRemoved(string $username): void
+    public function userWasRemoved(): void
     {
         $this->assertPageContainsText('L\'utilisateur a bien été effacé');
 

--- a/tests/end-to-end/Context/User/Administrator/EditContext.php
+++ b/tests/end-to-end/Context/User/Administrator/EditContext.php
@@ -13,8 +13,8 @@ declare(strict_types=1);
 
 namespace Khatovar\Tests\EndToEnd\Context\User\Administrator;
 
+use Khatovar\Tests\EndToEnd\Assertion\AssertUsersAreAdministrableOnes;
 use Khatovar\Tests\EndToEnd\Context\User\UserRawContext;
-use Khatovar\Tests\EndToEnd\Service\Assert\AssertUsersAreAdministrableOnes;
 
 /**
  * @author Damien Carcel <damien.carcel@gmail.com>

--- a/tests/end-to-end/Context/User/Administrator/ListContext.php
+++ b/tests/end-to-end/Context/User/Administrator/ListContext.php
@@ -13,8 +13,8 @@ declare(strict_types=1);
 
 namespace Khatovar\Tests\EndToEnd\Context\User\Administrator;
 
+use Khatovar\Tests\EndToEnd\Assertion\AssertUsersAreAdministrableOnes;
 use Khatovar\Tests\EndToEnd\Context\User\UserRawContext;
-use Khatovar\Tests\EndToEnd\Service\Assert\AssertUsersAreAdministrableOnes;
 
 /**
  * @author Damien Carcel <damien.carcel@gmail.com>

--- a/tests/end-to-end/Context/User/Anonymous/AuthenticationContext.php
+++ b/tests/end-to-end/Context/User/Anonymous/AuthenticationContext.php
@@ -23,9 +23,9 @@ declare(strict_types=1);
 
 namespace Khatovar\Tests\EndToEnd\Context\User\Anonymous;
 
+use Khatovar\Tests\EndToEnd\Assertion\AssertAuthenticatedAsUser;
+use Khatovar\Tests\EndToEnd\Assertion\AssertUserIsAnonymous;
 use Khatovar\Tests\EndToEnd\Context\User\UserRawContext;
-use Khatovar\Tests\EndToEnd\Service\Assert\AssertAuthenticatedAsUser;
-use Khatovar\Tests\EndToEnd\Service\Assert\AssertUserIsAnonymous;
 
 /**
  * @author Damien Carcel <damien.carcel@gmail.com>

--- a/tests/end-to-end/Context/User/Anonymous/RegisterNewUserContext.php
+++ b/tests/end-to-end/Context/User/Anonymous/RegisterNewUserContext.php
@@ -14,9 +14,9 @@ declare(strict_types=1);
 namespace Khatovar\Tests\EndToEnd\Context\User\Anonymous;
 
 use Khatovar\Component\User\Domain\Repository\UserRepositoryInterface;
+use Khatovar\Tests\EndToEnd\Assertion\AssertAuthenticatedAsUser;
+use Khatovar\Tests\EndToEnd\Assertion\AssertUserIsAnonymous;
 use Khatovar\Tests\EndToEnd\Context\User\UserRawContext;
-use Khatovar\Tests\EndToEnd\Service\Assert\AssertAuthenticatedAsUser;
-use Khatovar\Tests\EndToEnd\Service\Assert\AssertUserIsAnonymous;
 
 /**
  * @author Damien Carcel <damien.carcel@gmail.com>

--- a/tests/end-to-end/Resources/config/services.yml
+++ b/tests/end-to-end/Resources/config/services.yml
@@ -1,12 +1,12 @@
 services:
-    Khatovar\Tests\EndToEnd\Service\Assert\AssertAuthenticatedAsUser:
+    Khatovar\Tests\EndToEnd\Assertion\AssertAuthenticatedAsUser:
         arguments:
             - '@kernel'
 
-    Khatovar\Tests\EndToEnd\Service\Assert\AssertUserIsAnonymous:
+    Khatovar\Tests\EndToEnd\Assertion\AssertUserIsAnonymous:
         arguments:
             - '@kernel'
 
-    Khatovar\Tests\EndToEnd\Service\Assert\AssertUsersAreAdministrableOnes:
+    Khatovar\Tests\EndToEnd\Assertion\AssertUsersAreAdministrableOnes:
         arguments:
             - '@kernel'

--- a/tests/features/user/administrator/delete.feature
+++ b/tests/features/user/administrator/delete.feature
@@ -8,4 +8,4 @@ Feature: Delete a user account
   Scenario: I can delete a user
     Given I am logged as an administrator
     When I remove the user damien
-    Then I should be notified that user damien was removed
+    Then I should be notified that it was removed


### PR DESCRIPTION
## Description

This PR moves the test assertions in a better namespace.
It also makes `xdebug` activable on-demand in the `php` container.

## Definition Of Done

| Q                 | A
| ------------------| ---
| Specifications    | -
| Acceptance tests  | -
| Integration tests | -
| End to End tests  | -
| Changelog         | -
| Documentation     | -
| Related tickets   | #96

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
