### PR TITLE
Issue 95: Fix command order in install make target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,11 +60,11 @@ assets:
 	docker-compose run --rm node yarn run assets
 
 .PHONY: server-run
-server-run: install-dependencies assets mysql
+server-run: install-dependencies mysql assets
 	docker-compose run --rm --service-ports php bin/console server:run -d www 0.0.0.0:8000
 
 .PHONY: install
-install: install-dependencies assets mysql
+install: install-dependencies mysql assets
 	docker-compose up -d nginx
 
 # Clean the containers


### PR DESCRIPTION
## Description

`assets` must be run after `mysql` because Symfony `assets:install` needs the MySQL database to be up.

## Definition Of Done

| Q                 | A
| ------------------| ---
| Specifications    | -
| Acceptance tests  | -
| Integration tests | -
| End to End tests  | -
| Changelog         | -
| Documentation     | -
| Related tickets   | #95

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
