### PR TITLE
Issue 95: Always use HTTPS with Docker

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -50,7 +50,13 @@ services:
       - 'fpm'
     image: 'nginx:alpine'
     labels:
+      - 'traefik.http.middlewares.redirect-khatovar-http-to-https.redirectScheme.scheme=https'
+      - 'traefik.http.routers.khatovar.entrypoints=web'
+      - 'traefik.http.routers.khatovar.middlewares=redirect-khatovar-http-to-https'
       - 'traefik.http.routers.khatovar.rule=Host(`khatovar.docker.localhost`)'
+      - 'traefik.http.routers.khatovar-with-https.entrypoints=websecure'
+      - 'traefik.http.routers.khatovar-with-https.rule=Host(`khatovar.docker.localhost`)'
+      - 'traefik.http.routers.khatovar-with-https.tls=true'
     volumes:
       - './:/srv/khatovar:ro'
       - './docker/nginx/default.conf:/etc/nginx/conf.d/default.conf:ro'


### PR DESCRIPTION
## Description

Use recently update [Traefik configuration](https://github.com/damien-carcel/traefik-as-local-reverse-proxy) to access the application through HTTPS.

## Definition Of Done

| Q                 | A
| ------------------| ---
| Specifications    | -
| Acceptance tests  | -
| Integration tests | -
| End to End tests  | -
| Changelog         | -
| Documentation     | -
| Related tickets   | #95

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
